### PR TITLE
Adds functionality for triggering custom commands on ticket close and playing a sound effect to all online staff on ticket creation

### DIFF
--- a/src/main/java/com/battleasya/admin360/entities/Admin.java
+++ b/src/main/java/com/battleasya/admin360/entities/Admin.java
@@ -27,6 +27,19 @@ public class Admin {
         }
     }
 
+    /* Play a sound effect for all the admins online */
+    public static void playSoundAdmins(String sound) {
+
+        for (UUID adminID : adminList) {
+            
+            Player admin = Bukkit.getPlayer(adminID);
+
+            if (admin != null) {
+                User.playSoundPlayer(admin, sound);
+            }
+        }
+    }
+
     /* Refresh all the admins in the list */
     public static void refreshAdmLst() {
         Collection<? extends Player> playerList = Bukkit.getOnlinePlayers();

--- a/src/main/java/com/battleasya/admin360/entities/Request.java
+++ b/src/main/java/com/battleasya/admin360/entities/Request.java
@@ -2,6 +2,11 @@ package com.battleasya.admin360.entities;
 
 import java.util.*;
 
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+
+import com.battleasya.admin360.handler.Config;
+
 public class Request {
 
     public static int completedToday = 0;
@@ -128,7 +133,15 @@ public class Request {
         // Remove from requestAttending
         for (Map.Entry<UUID, Request> entry : requestAttending.entrySet()) {
             if (entry.getValue().getPlayerID().equals(playerID)){
-                removeFromAtdLst(entry.getKey());
+                UUID adminID = entry.getKey();
+
+                // Un-invincibilize admin
+                if (Config.attend_invincibility) {
+                    Player admin = Bukkit.getPlayer(adminID);
+                    User.messagePlayer(admin, Config.invulnerable_off);
+                    ((Player) admin).setInvulnerable(false);
+                }   
+                removeFromAtdLst(adminID);
                 break; // prevent concurrent modification error
             }
         }

--- a/src/main/java/com/battleasya/admin360/entities/User.java
+++ b/src/main/java/com/battleasya/admin360/entities/User.java
@@ -4,6 +4,8 @@ import com.battleasya.admin360.Admin360;
 import com.battleasya.admin360.handler.Config;
 import com.battleasya.admin360.handler.Permission;
 import net.md_5.bungee.api.ChatColor;
+
+import org.bukkit.Bukkit;
 import org.bukkit.command.CommandSender;
 import org.bukkit.scheduler.BukkitRunnable;
 
@@ -18,6 +20,15 @@ public class User {
 
     public static void messagePlayer(CommandSender player, String message) {
         player.sendMessage(translate(message));
+    }
+
+    public static void playSoundPlayer(CommandSender player, String sound) {
+
+        String command = "execute at <PLAYERNAME> run playsound <SOUND> master <PLAYERNAME> ~ ~ ~";
+
+        Bukkit.dispatchCommand(Bukkit.getConsoleSender(), command
+                .replace("<SOUND>", sound)
+                .replace("<PLAYERNAME>", player.getName())); 
     }
 
     public static String translate(String message) {

--- a/src/main/java/com/battleasya/admin360/handler/Config.java
+++ b/src/main/java/com/battleasya/admin360/handler/Config.java
@@ -53,6 +53,9 @@ public class Config {
     public static boolean create_passed_trigger_enable;
     public static List<String> create_passed_trigger_command;
 
+    public static boolean create_passed_sound_effect_enable;
+    public static String create_passed_sound_effect_sound;
+
     public static String cancel_failed_no_ticket;
     public static String cancel_failed_attending;
     public static String cancel_failed_restricted;
@@ -228,6 +231,9 @@ public class Config {
 
         create_passed_trigger_enable = config.getBoolean("create.passed.trigger.enable");
         create_passed_trigger_command = config.getStringList("create.passed.trigger.command");
+
+        create_passed_sound_effect_enable = config.getBoolean("create.passed.sound-effect.enable");
+        create_passed_sound_effect_sound = config.getString("create.passed.sound-effect.sound");
 
         cancel_failed_no_ticket = config.getString("cancel.failed.message.no-ticket");
         cancel_failed_attending = config.getString("cancel.failed.message.attending");

--- a/src/main/java/com/battleasya/admin360/handler/Config.java
+++ b/src/main/java/com/battleasya/admin360/handler/Config.java
@@ -110,6 +110,9 @@ public class Config {
     public static String close_failed;
     public static String close_passed;
 
+    public static boolean close_passed_trigger_enable;
+    public static List<String> close_passed_trigger_command;
+
     public static boolean review_reminder_enable;
     public static int review_reminder_interval;
 
@@ -283,6 +286,9 @@ public class Config {
 
         close_failed = config.getString("close.failed.message");
         close_passed = config.getString("close.passed.message");
+
+        close_passed_trigger_enable = config.getBoolean("close.passed.trigger.enable");
+        close_passed_trigger_command = config.getStringList("close.passed.trigger.command");
 
         review_reminder_enable = config.getBoolean("review.reminder.enable");
         review_reminder_interval = config.getInt("review.reminder.interval");

--- a/src/main/java/com/battleasya/admin360/handler/RequestHandler.java
+++ b/src/main/java/com/battleasya/admin360/handler/RequestHandler.java
@@ -435,6 +435,14 @@ public class RequestHandler {
             ((Player) admin).setInvulnerable(false);
         }
 
+        // trigger custom commands
+        if (Config.close_passed_trigger_enable) {
+            for (String command : Config.close_passed_trigger_command) {
+                Bukkit.dispatchCommand(Bukkit.getConsoleSender(), command
+                        .replace("<PLAYERNAME>", playerName)
+                        .replace("<ADMINNAME>", adminName));
+            }
+        }
     }
 
 

--- a/src/main/java/com/battleasya/admin360/handler/RequestHandler.java
+++ b/src/main/java/com/battleasya/admin360/handler/RequestHandler.java
@@ -95,6 +95,11 @@ public class RequestHandler {
             }
         }
 
+        // play sound for online staff
+        if (Config.create_passed_sound_effect_enable) {
+            Admin.playSoundAdmins(Config.create_passed_sound_effect_sound);
+        }
+
     }
 
 

--- a/src/main/java/com/battleasya/admin360/handler/RequestHandler.java
+++ b/src/main/java/com/battleasya/admin360/handler/RequestHandler.java
@@ -324,6 +324,12 @@ public class RequestHandler {
                     .replace("<ADMINNAME>", adminName));
         }
 
+        // Un-invincibilize admin
+        if (Config.attend_invincibility) {
+            User.messagePlayer(admin, Config.invulnerable_off);
+            ((Player) admin).setInvulnerable(false);
+        }
+
     }
 
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -166,6 +166,12 @@ create:
       enable: false
       command:
         - "tm msg <PLAYERNAME> &b\n&6Ticket Created &7(&fPosition: &6<POSITION>&7)"
+    
+    # Notify all online staff members with a sound. Default sound is the minecraft xp gain sound.
+    # sound should be a resource location.
+    sound-effect:
+      enable: false
+      sound: "entity.experience_orb.pickup"
 
 
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -463,6 +463,12 @@ close:
   passed:
     message: "&f[&6ADMIN360&f] &7You have successfully closed &6<PLAYERNAME>&7's request."
 
+    # Run console commands on ticket close. Default example using /say.
+    trigger:
+      enable: false
+      command:
+        - "say A ticket has been closed!"
+
 
 
 ############################################################


### PR DESCRIPTION
**Ticket Close:**
- Implements the ability to trigger custom commands when a ticket is closed. 
- Updated default config.yml to enable/disable and set custom commands to be executed.

**Ticket Open:**
- Implements the ability for a sound to be played to all online staff upon creation of a ticket.
- Updated default config.yml to enable/disable and choose sound to be played.